### PR TITLE
PowerShell: Add support for multiple drives

### DIFF
--- a/openssl_scan.ps1
+++ b/openssl_scan.ps1
@@ -1,6 +1,6 @@
 # BEGIN CONFIG
 # set to $true to scan all drives
-$scanalldrives = $true
+$scan_all_drives = $true
 
 # set the directory to search for OpenSSL libraries in (default: C:\)
 # only needed if scanalldrives is $false !
@@ -20,7 +20,7 @@ if ($confirm -eq “confirm”) {
 	    $regex = "OpenSSL\s*[0-9].[0-9].[0-9]"
     }
 
-    if ($scanalldrives){
+    if ($scan_all_drives){
         $search_directory =  (Get-PSDrive -PSProvider FileSystem).Root
     }
 

--- a/openssl_scan.ps1
+++ b/openssl_scan.ps1
@@ -1,6 +1,6 @@
 # BEGIN CONFIG
 # set to $true to scan all drives
-$scan_all_drives = $true
+$scan_all_drives = $false
 
 # set the directory to search for OpenSSL libraries in (default: C:\)
 # only needed if scanalldrives is $false !

--- a/openssl_scan.ps1
+++ b/openssl_scan.ps1
@@ -1,5 +1,9 @@
 # BEGIN CONFIG
+# set to $true to scan all drives
+$scanalldrives = $true
+
 # set the directory to search for OpenSSL libraries in (default: C:\)
+# only needed if scanalldrives is $false !
 $search_directory = “C:\”
 
 # set to $true to show only OpenSSL version vulnerable to this bug
@@ -14,6 +18,10 @@ if ($confirm -eq “confirm”) {
 	    $regex = "OpenSSL\s*3.0.[0-6]"
     }else{
 	    $regex = "OpenSSL\s*[0-9].[0-9].[0-9]"
+    }
+
+    if ($scanalldrives){
+        $searchdirectory =  (Get-PSDrive -PSProvider FileSystem).Root
     }
 
     # search for any DLLs whose name begins with libcrypto

--- a/openssl_scan.ps1
+++ b/openssl_scan.ps1
@@ -21,7 +21,7 @@ if ($confirm -eq “confirm”) {
     }
 
     if ($scanalldrives){
-        $searchdirectory =  (Get-PSDrive -PSProvider FileSystem).Root
+        $search_directory =  (Get-PSDrive -PSProvider FileSystem).Root
     }
 
     # search for any DLLs whose name begins with libcrypto

--- a/openssl_scan.ps1
+++ b/openssl_scan.ps1
@@ -34,5 +34,5 @@ if ($confirm -eq "confirm") {
 	    }
     }
 }else{
-    echo “aborting”
+    echo "aborting"
 }


### PR DESCRIPTION
These changes add support for multiple drives in the script. This way you can scan both C and D drive for example.