### PR TITLE
Fix a few bugs, add a few small improvements

### DIFF
--- a/openssl_scan.sh
+++ b/openssl_scan.sh
@@ -1,33 +1,41 @@
-# BEGIN CONFIG
-# set the directory to search for OpenSSL libraries in (default: /)
-search_directory=/
+#!/usr/bin/env bash
+set -uo pipefail
 
+# BEGIN CONFIG
 # set to 1 to show only OpenSSL version vulnerable to this bug
 only_vulnerable=0
+if [[ "$1" = '-o' ]]; then
+    only_vulnerable=1
+    shift
+fi
+
+# set the directory to search for OpenSSL libraries in (default: /)
+search_directory="${1:-/}"
 #END CONFIG
 
-echo This is an example script not meant for production use. To confirm that you understand and accept all responsibility, type: confirm
-read confirm
+echo 'This is an example script not meant for production use. To confirm that you understand and accept all responsibility, type: confirm'
+read -r confirm
 
-if [[ "$confirm" == "confirm" ]]; then
-    if [[ $only_vulnerable -eq 1 ]]; then
-        regex="^OpenSSL\s*3.0.[0-6]"
+if [[ "$confirm" != "confirm" ]]; then
+    if (( only_vulnerable )); then
+        regex='^OpenSSL\s*3\.0\.[0-6]'
     else
-        regex="^OpenSSL\s*[0-9].[0-9].[0-9]"
+        regex='^OpenSSL\s*[0-9]\.[0-9]\.[0-9]'
     fi
 
-    if ! command -v strings &> /dev/null
-    then
+    if ! command -v strings &> /dev/null; then
         echo "strings could not be found, please install it and try again"
-        exit
+        exit 1
     fi
 
-    for file_name in $(find $search_directory -type f -name "libcrypto*.so*" -o -name "libssl*.so*" -o -name "libssl*.a*" -o -name "libcrypto*.a*"); do
-        openssl_version=$( strings "$file_name" | grep "$regex")
-        if [[ $openssl_version ]]; then
-            echo  "$openssl_version" - "$file_name"
-        fi
+    find "$search_directory" -type f '(' -name "libcrypto*.so*" -o -name "libssl*.so*" -o -name "libssl*.a*" -o -name "libcrypto*.a*" ')' | while read -r file_name; do
+        strings -- "$file_name" | grep -e "$regex" | while read -r openssl_version; do
+            echo "$openssl_version - $file_name"
+        done
     done
+
+    true
 else
     echo aborting
+    exit 1
 fi


### PR DESCRIPTION
Changes include:

1. Regexes weren't ideal: `.` matches any non-line-break character unless escaped
2. `find` operator precedence: `-type f` was only being ANDed with `-name "libcrypto*.so*"`
3. If multiple strings matched the regex, output would get a bit wonky
4. echo text should've been quoted to avoid issues with non-bash-but-bash-like shells
5. `set -uo pipefail` helps avoid some pitfalls
6. Can't hurt to pass `-r` to `read` just to avoid some odd behavior when certain input is passed
7. Regexes should probably have single quotes just to avoid issues with backslashes
8. Explicitly passing `-e` to `grep` avoids issues that might arise if someone edits the regexes
9. Explicitly passing `--` to strings
10. Allow config to be set via command line (rudimentary)
11. Shebang line to make it clear this requires bash, not sh/ash/dash
12. Misc consistency and cleanup