### PR TITLE
Fixed non-ascii double quotes around C:\

### DIFF
--- a/openssl_scan.ps1
+++ b/openssl_scan.ps1
@@ -4,7 +4,7 @@ $scan_all_drives = $false
 
 # set the directory to search for OpenSSL libraries in (default: C:\)
 # only needed if scanalldrives is $false !
-$search_directory = “C:\”
+$search_directory = "C:\"
 
 # set to $true to show only OpenSSL version vulnerable to this bug
 $only_vulnerable = $false


### PR DESCRIPTION
```
â€œC:\â€ : The term 'â€œC:\â€' is not recognized as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
```